### PR TITLE
Fix exp char weap

### DIFF
--- a/data/game/inventoryItem/gameInventoryItem.js
+++ b/data/game/inventoryItem/gameInventoryItem.js
@@ -42,12 +42,12 @@ export const allInventoryItems = {
 };
 
 import * as gameInventoryItemsConfig from '~/data/game/inventoryItem/gameInventoryItemConfig';
-export const tiered_materials = {
-	...gameInventoryItemsConfig.tiered_materials,
+export const tiered_materials_per_type = {
+	...gameInventoryItemsConfig.tiered_materials_per_type,
 };
 
 export const synthesizable_materials = {
-	...gameInventoryItemsConfig.tiered_materials_2,
+	...gameInventoryItemsConfig.tiered_materials_all,
 };
 
 export const exp_data = {

--- a/data/game/inventoryItem/gameInventoryItemConfig.js
+++ b/data/game/inventoryItem/gameInventoryItemConfig.js
@@ -44,9 +44,15 @@ import {
 	tiered_forgery_weapon_skill_material_index_name,
 } from '@/data/game/inventoryItem/tiered/forgeryWeaponSkillMaterial';
 
+import {
+	tiered_char_exp_index_category,
+	tiered_char_exp_index_name,
+} from '@/data/game/inventoryItem/tiered/characterExp';
+
 export const tiered_materials_all = {
 	...tiered_enemy_drop_weapon_skill_material_index_name,
 	...tiered_forgery_weapon_skill_material_index_name,
+	...tiered_char_exp_index_name,
 };
 
 export const tiered_materials_per_type = {
@@ -54,6 +60,7 @@ export const tiered_materials_per_type = {
 		tiered_enemy_drop_weapon_skill_material_index_category,
 	tiered_forgery_weapon_skill_material:
 		tiered_forgery_weapon_skill_material_index_category,
+	tiered_char_exp: tiered_char_exp_index_category,
 };
 
 export const exp_data = {

--- a/data/game/inventoryItem/gameInventoryItemConfig.js
+++ b/data/game/inventoryItem/gameInventoryItemConfig.js
@@ -49,10 +49,16 @@ import {
 	tiered_char_exp_index_name,
 } from '@/data/game/inventoryItem/tiered/characterExp';
 
+import {
+	tiered_weap_exp_index_category,
+	tiered_weap_exp_index_name,
+} from '@/data/game/inventoryItem/tiered/weaponExp';
+
 export const tiered_materials_all = {
 	...tiered_enemy_drop_weapon_skill_material_index_name,
 	...tiered_forgery_weapon_skill_material_index_name,
 	...tiered_char_exp_index_name,
+	...tiered_weap_exp_index_name,
 };
 
 export const tiered_materials_per_type = {
@@ -61,6 +67,7 @@ export const tiered_materials_per_type = {
 	tiered_forgery_weapon_skill_material:
 		tiered_forgery_weapon_skill_material_index_category,
 	tiered_char_exp: tiered_char_exp_index_category,
+	tiered_weap_exp: tiered_weap_exp_index_category,
 };
 
 export const exp_data = {

--- a/data/game/inventoryItem/gameInventoryItemConfig.js
+++ b/data/game/inventoryItem/gameInventoryItemConfig.js
@@ -44,12 +44,12 @@ import {
 	tiered_forgery_weapon_skill_material_index_name,
 } from '@/data/game/inventoryItem/tiered/forgeryWeaponSkillMaterial';
 
-export const tiered_materials_2 = {
+export const tiered_materials_all = {
 	...tiered_enemy_drop_weapon_skill_material_index_name,
 	...tiered_forgery_weapon_skill_material_index_name,
 };
 
-export const tiered_materials = {
+export const tiered_materials_per_type = {
 	tiered_enemy_drop_weapon_skill_material:
 		tiered_enemy_drop_weapon_skill_material_index_category,
 	tiered_forgery_weapon_skill_material:

--- a/data/game/inventoryItem/tiered/characterExp.js
+++ b/data/game/inventoryItem/tiered/characterExp.js
@@ -1,0 +1,46 @@
+export const char_exp_proper_data = [
+	{
+		general_name: 'resonane_potion',
+		name: 'basic_resonance_potion',
+		tier: 1,
+		from: undefined,
+		to: 'medium_resonance_potion',
+		count: 3000 / 1000,
+		exp_value: 1000,
+	},
+	{
+		general_name: 'resonane_potion',
+		name: 'medium_resonance_potion',
+		tier: 2,
+		from: 'basic_resonance_potion',
+		to: 'advanced_resonance_potion',
+		count: 8000 / 3000,
+		exp_value: 3000,
+	},
+	{
+		general_name: 'resonane_potion',
+		name: 'advanced_resonance_potion',
+		tier: 3,
+		from: 'medium_resonance_potion',
+		to: 'premium_resonance_potion',
+		count: 20000 / 8000,
+		exp_value: 8000,
+	},
+	{
+		general_name: 'resonane_potion',
+		name: 'premium_resonance_potion',
+		tier: 4,
+		from: 'advanced_resonance_potion',
+		to: undefined,
+		count: undefined,
+		exp_value: 20000,
+	},
+];
+
+import * as utilites from '~/data/game/inventoryItem/utilities';
+
+export const tiered_char_exp_index_category =
+	utilites.tiered_material_index_category(char_exp_proper_data);
+
+export const tiered_char_exp_index_name =
+	utilites.tiered_material_index_name(char_exp_proper_data);

--- a/data/game/inventoryItem/tiered/characterExp.js
+++ b/data/game/inventoryItem/tiered/characterExp.js
@@ -5,7 +5,7 @@ export const char_exp_proper_data = [
 		tier: 1,
 		from: undefined,
 		to: 'medium_resonance_potion',
-		count: 3000 / 1000,
+		count: 3000.0 / 1000,
 		exp_value: 1000,
 	},
 	{
@@ -14,7 +14,7 @@ export const char_exp_proper_data = [
 		tier: 2,
 		from: 'basic_resonance_potion',
 		to: 'advanced_resonance_potion',
-		count: 8000 / 3000,
+		count: 8000.0 / 3000,
 		exp_value: 3000,
 	},
 	{
@@ -23,7 +23,7 @@ export const char_exp_proper_data = [
 		tier: 3,
 		from: 'medium_resonance_potion',
 		to: 'premium_resonance_potion',
-		count: 20000 / 8000,
+		count: 20000.0 / 8000,
 		exp_value: 8000,
 	},
 	{

--- a/data/game/inventoryItem/tiered/weaponExp.js
+++ b/data/game/inventoryItem/tiered/weaponExp.js
@@ -1,0 +1,46 @@
+export const weap_proper_data = [
+	{
+		general_name: 'energy_core',
+		name: 'basic_energy_core',
+		tier: 1,
+		from: undefined,
+		to: 'medium_energy_core',
+		count: 3000.0 / 1000,
+		exp_value: 1000,
+	},
+	{
+		general_name: 'energy_core',
+		name: 'medium_energy_core',
+		tier: 2,
+		from: 'basic_energy_core',
+		to: 'advanced_energy_core',
+		count: 8000.0 / 3000,
+		exp_value: 3000,
+	},
+	{
+		general_name: 'energy_core',
+		name: 'advanced_energy_core',
+		tier: 3,
+		from: 'medium_energy_core',
+		to: 'premium_energy_core',
+		count: 20000.0 / 8000,
+		exp_value: 8000,
+	},
+	{
+		general_name: 'energy_core',
+		name: 'premium_energy_core',
+		tier: 4,
+		from: 'advanced_energy_core',
+		to: undefined,
+		count: undefined,
+		exp_value: 20000,
+	},
+];
+
+import * as utilites from '~/data/game/inventoryItem/utilities';
+
+export const tiered_weap_exp_index_category =
+	utilites.tiered_material_index_category(weap_proper_data);
+
+export const tiered_weap_exp_index_name =
+	utilites.tiered_material_index_name(weap_proper_data);

--- a/data/game/inventoryItem/utilities.js
+++ b/data/game/inventoryItem/utilities.js
@@ -1,0 +1,32 @@
+export const tiered_material_index_category = (proper_data) => {
+	return Object.keys(proper_data).reduce((acc, key) => {
+		const { general_name, name, tier, from, to, count } = proper_data[key];
+		acc[general_name] = acc[general_name] || {};
+		if (to) {
+			acc[general_name][tier] = {
+				name,
+				synthesizable: {
+					to: tier,
+					count,
+				},
+			};
+		} else {
+			acc[general_name][tier] = {
+				name,
+			};
+		}
+		return acc;
+	}, {});
+};
+
+export const tiered_material_index_name = (proper_data) => {
+	return Object.keys(proper_data).reduce((acc, key) => {
+		const { general_name, name, from, to, count } = proper_data[key];
+		acc[name] = {
+			to: to,
+			cost: count,
+		};
+		if (from) acc[name].from = from;
+		return acc;
+	}, {});
+};

--- a/services/inventoryService.js
+++ b/services/inventoryService.js
@@ -176,9 +176,10 @@ export const getOwnedNeededMaterialsResponseData = (neededMaterials) => {
 				// recalculate synthesized so that only syntesized what's needed
 
 				// calculate synthesized that is needed for higher tier
-				let synthesizedNeededForHigherTier =
+				let synthesizedNeededForHigherTier = Math.floor(
 					responseDataSorted[upperTierRecheckedMaterial].synthesized *
-					gameInventoryItem.synthesizable_materials[recheckedMaterial].cost;
+						gameInventoryItem.synthesizable_materials[recheckedMaterial].cost
+				);
 
 				// needed current tier + needed for higher tier - owned
 				// = synthesized from lower tier

--- a/services/planner/utilities.js
+++ b/services/planner/utilities.js
@@ -24,7 +24,9 @@ export const getLevelRangeDiff = (arrayData, currentLevel, targetLevel) => {
 };
 
 export const isTieredMaterialType = (material) => {
-	return Object.keys(gameInventoryItem.tiered_materials).includes(material);
+	return Object.keys(gameInventoryItem.tiered_materials_per_type).includes(
+		material
+	);
 };
 
 export const getMaterialsFromLevelListStatList = (
@@ -56,9 +58,9 @@ export const getMaterialsFromLevelListStatList = (
 				if (isTieredMaterialType(materialType)) {
 					for (let tier in level.materials[materialType]) {
 						const tieredMaterialName =
-							gameInventoryItem.tiered_materials[materialType][materialName][
-								tier
-							].name;
+							gameInventoryItem.tiered_materials_per_type[materialType][
+								materialName
+							][tier].name;
 						useSet(
 							materials,
 							tieredMaterialName,

--- a/stores/inventoryItemStore.js
+++ b/stores/inventoryItemStore.js
@@ -64,7 +64,7 @@ export const useInventoryItemStore = defineStore('inventoryItems', () => {
 					gameInventoryItem.synthesizable_materials[lowerTierMaterial].cost;
 				return decreaseTieredMaterial(
 					lowerTierMaterial,
-					synthesizedCost * updatedValue * -1
+					Math.floor(synthesizedCost * updatedValue * -1)
 				);
 			}
 		} else {


### PR DESCRIPTION
character and weapon exp should behave properly.

changes:

- now `char_exp` and `weap_exp` are part of tiered materials.
- it's not actually synthesizable, but behave similarly as higher tier material has conversion cost/value comparison.

possible unexpected behaviour:

- the material count deduction (when setting char/weap to DONE) might be incorrect because it's not checked in-game. but the exp calculation should correct. 

also in this PR:

- rename `tiered_materials_2` and `tiered_materials`
- refactor indexing function that is used for `char_exp` and `weap_exp` which should be able to be used by previous tiered materials (same code algo).