### PR TITLE
Minor bugfixes to the stamina updating and toast popups

### DIFF
--- a/components/inventoryItem/InventoryItemMaterialCard.vue
+++ b/components/inventoryItem/InventoryItemMaterialCard.vue
@@ -117,16 +117,22 @@ const ownedItemColor = computed(() => {
 });
 
 const toast = useToast();
+let toastId = null;
 const itemRef = ref(0);
 
 const updateMaterialCount = (index, count) => {
 	debouncedUpdateMaterialCount(index, count).then(() => {
-		toast.add({
-			title: 'Inventory Item ' + props.item.label + ' updated to LocalStorage',
-			icon: 'i-heroicons-check-badge',
-			timeout: 2000,
+		toast.remove('inventory-update');
+
+		nextTick(() => {
+			toastId = toast.add({
+				id: 'inventory-update',
+				title: 'Inventory Item ' + props.item.label + ' updated to LocalStorage',
+				icon: 'i-heroicons-check-badge',
+				timeout: 2000,
+			});
+			$emit('updateMaterialCount', true);
 		});
-		$emit('updateMaterialCount', true);
 	});
 };
 

--- a/pages/characters/index.vue
+++ b/pages/characters/index.vue
@@ -164,17 +164,17 @@
 </template>
 
 <script setup>
-import { characters } from '~/data/game/gameCharacter';
-import * as dbPlannedCharacter from '~/data/database/dbPlannedCharacter';
-import {
-	levelItems,
-	activeSkills,
-	passiveSkills,
-} from '~/data/form/characters/formCharactersNew';
-import { usePlannedCharacterStore } from '@/stores/plannedCharacterStore';
 import * as characterService from '@/services/characterService';
 import * as inventoryService from '@/services/inventoryService';
 import * as plannerService from '@/services/plannerService';
+import { usePlannedCharacterStore } from '@/stores/plannedCharacterStore';
+import * as dbPlannedCharacter from '~/data/database/dbPlannedCharacter';
+import {
+	activeSkills,
+	levelItems,
+	passiveSkills,
+} from '~/data/form/characters/formCharactersNew';
+import { characters } from '~/data/game/gameCharacter';
 
 const characterList = () => {
 	let list = [];
@@ -224,6 +224,7 @@ const getOrInitPlannedCharacter = (characterName) => {
 };
 
 const toast = useToast();
+let toastId = null;
 
 const upsertPlannedCharacter = () => {
 	useDebounceFn(() => {
@@ -238,15 +239,20 @@ const upsertPlannedCharacter = () => {
 		if (!characterName.value) {
 			return;
 		}
-		toast.add({
-			title:
-				'Character ' +
-				characters[characterName.value].display_name +
-				' updated to LocalStorage',
-			icon: 'i-heroicons-check-badge',
-			timeout: 2000,
+		toast.remove('character-update');
+		
+		nextTick(() => {
+			toastId = toast.add({
+				id: 'character-update',
+				title:
+					'Character ' +
+					characters[characterName.value].display_name +
+					' updated to LocalStorage',
+				icon: 'i-heroicons-check-badge',
+				timeout: 2000,
+			});
+			materials.value = getNeededMaterials(characterName.value);
 		});
-		materials.value = getNeededMaterials(characterName.value);
 	});
 };
 

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -55,6 +55,7 @@ const toast = useToast();
 const submitUploadData = () => {
 	if (!uploadedJsonTextArea.value) {
 		toast.add({
+			id: 'missing-json',
 			title: 'No JSON data selected',
 			icon: 'i-heroicons-x-mark',
 			timeout: 2000,
@@ -68,6 +69,7 @@ const submitUploadData = () => {
 
 	uploadedJsonTextArea.value = null;
 	toast.add({
+		id: 'data-restore',
 		title: 'Data successfully restored: ' + result.join(', '),
 		icon: 'i-heroicons-check-badge',
 		timeout: 2000,

--- a/pages/weapons/index.vue
+++ b/pages/weapons/index.vue
@@ -98,13 +98,13 @@
 </template>
 
 <script setup>
-import { weapons } from '~/data/game/gameWeapon';
 import * as dbPlannedWeapon from '@/data/database/dbPlannedWeapon';
 import { levelItems } from '@/data/form/weapons/formWeaponsNew';
-import { usePlannedWeaponStore } from '@/stores/plannedWeaponStore';
-import * as weaponService from '@/services/weaponService';
 import * as inventoryService from '@/services/inventoryService';
 import * as plannerService from '@/services/plannerService';
+import * as weaponService from '@/services/weaponService';
+import { usePlannedWeaponStore } from '@/stores/plannedWeaponStore';
+import { weapons } from '~/data/game/gameWeapon';
 
 const weaponList = () => {
 	let list = [];
@@ -162,6 +162,7 @@ const getOrInitPlannedWeapon = (weaponName) => {
 };
 
 const toast = useToast();
+let toastId = null;
 
 const upsertPlannedWeapon = () => {
 	useDebounceFn(() => {
@@ -177,15 +178,17 @@ const upsertPlannedWeapon = () => {
 		if (!weaponName.value) {
 			return;
 		}
-		toast.add({
-			title:
-				'Weapon ' +
-				weapons[weaponName.value].display_name +
-				' updated to LocalStorage',
-			icon: 'i-heroicons-check-badge',
-			timeout: 2000,
-		});
+		toast.remove('weapon-update');
+
+		nextTick(() => {
+			toastId = toast.add({
+				id:'weapon-update',
+				title:'Weapon ' + weapons[weaponName.value].display_name + ' updated to LocalStorage',
+				icon: 'i-heroicons-check-badge',
+				timeout: 2000,
+			});
 		materials.value = getNeededMaterials(weaponName.value);
+        });
 	});
 };
 

--- a/stores/staminaStore.js
+++ b/stores/staminaStore.js
@@ -1,5 +1,5 @@
-import { MAX_STAMINA, getSecondsPerStamina } from '~/libraries/constants';
 import { useStorage } from '@vueuse/core';
+import { MAX_STAMINA, getSecondsPerStamina } from '~/libraries/constants';
 
 const staminaRepo = () => {
 	return useStorage('stamina', {
@@ -72,8 +72,14 @@ export const useStaminaStore = defineStore('stamina', () => {
 			if (stamina.value >= maxStamina.value) return;
 		}
 
-		// update stamina and staminaUpdatedAt
-		stamina.value += additionalStamina;
+		const staminaAddTest = (stamina.value + additionalStamina)
+
+		// If button presses result in overflow, set the stamina to max or min to keep within bounds
+		if (staminaAddTest > maxStamina.value) stamina.value = maxStamina.value
+		else if (staminaAddTest < 0) stamina.value = 0;
+		else stamina.value += additionalStamina;
+		
+		// update staminaUpdatedAt
 		const updatedAt = Date.now();
 		const alreadyRecoveringTime =
 			(updatedAt - staminaUpdatedAt.value) % (secondsPerStamina.value * 1000);


### PR DESCRIPTION
I wanted to help in some way, so to help me get used to a new framework I tackled a couple of minor bugs that were affecting my UX while using it for the past couple of months.

The bugs were as follows
- The planner originally had some overflow issues with the stamina buttons, clicking on the negative ones would eventually result in a negative stamina count overall, and likewise with the stamina addition buttons.
- When using the up or down arrow on the inventory or character inputs it would trigger the toast popup to overlap with the previous one, causing a stack of popups covering a portion of the screen for a short time. 

To address the issues
- The stamina update only needed some minor validation to ensure that the stamina calculation post-addition/subtraction was being tested and used before applying the changes to the counter
- The toast changes were a little trickier
  - Originally, when a toast is added without an ID, the system creates a new dom element for each toast addition
  - Only adding an ID field would not be enough since the toast would wait for the timeout to finish before reusing the element
  - I believe the original intention of the popup is to have it be responsive to every update, so I ensured that the toast state management removes the previous instance tied to the ID before adding the new one.
  - After removing it there is a tiny delay to ensure the state is clean to add the next toast, making it refresh the timeout
  - Those two changes allowed for only one toast of each ID to exist at the same time and if they get updated quickly they will remain as responsive as possible to reflect quick changes